### PR TITLE
Fixes unwanted parsing when warping to an island

### DIFF
--- a/src/main/java/world/bentobox/warps/commands/WarpCommand.java
+++ b/src/main/java/world/bentobox/warps/commands/WarpCommand.java
@@ -65,12 +65,10 @@ public class WarpCommand extends DelayedTeleportCommand {
                     } else {
                         // Alternative warp found!
                         this.delayCommand(user, () -> addon.getWarpSignsManager().warpPlayer(world, user, foundAlernativeWarp));
-                        addon.log("Found alternative, teleporting!");
                         return true;
                     }
                 } else {
                     // Warp exists!
-                    addon.log("Found exact warp, teleporting!");
                     this.delayCommand(user, () -> addon.getWarpSignsManager().warpPlayer(world, user, foundWarp));
                     return true;
                 }

--- a/src/main/java/world/bentobox/warps/commands/WarpCommand.java
+++ b/src/main/java/world/bentobox/warps/commands/WarpCommand.java
@@ -17,7 +17,6 @@ import world.bentobox.warps.Warp;
  * The /is warp <name> command
  *
  * @author tastybento
- *
  */
 public class WarpCommand extends DelayedTeleportCommand {
 
@@ -52,14 +51,26 @@ public class WarpCommand extends DelayedTeleportCommand {
                 user.sendMessage("warps.warpTip", "[text]", addon.getSettings().getWelcomeLine());
                 return false;
             } else {
-                // Check if this is part of a name
-                UUID foundWarp = warpList.stream().filter(u -> getPlayers().getName(u).equalsIgnoreCase(args.get(0))
-                        || getPlayers().getName(u).toLowerCase().startsWith(args.get(0).toLowerCase())).findFirst().orElse(null);
+                // Attemp to find warp with exact player's name
+                UUID foundWarp = warpList.stream().filter(u -> getPlayers().getName(u).equalsIgnoreCase(args.get(0))).findFirst().orElse(null);
+
                 if (foundWarp == null) {
-                    user.sendMessage("warps.error.does-not-exist");
-                    return false;
+
+                    // Atempt to find warp which starts with the given name
+                    UUID foundAlernativeWarp = warpList.stream().filter(u -> getPlayers().getName(u).toLowerCase().startsWith(args.get(0).toLowerCase())).findFirst().orElse(null);
+
+                    if (foundAlernativeWarp == null) {
+                        user.sendMessage("warps.error.does-not-exist");
+                        return false;
+                    } else {
+                        // Alternative warp found!
+                        this.delayCommand(user, () -> addon.getWarpSignsManager().warpPlayer(world, user, foundAlernativeWarp));
+                        addon.log("Found alternative, teleporting!");
+                        return true;
+                    }
                 } else {
                     // Warp exists!
+                    addon.log("Found exact warp, teleporting!");
                     this.delayCommand(user, () -> addon.getWarpSignsManager().warpPlayer(world, user, foundWarp));
                     return true;
                 }


### PR DESCRIPTION
Fixes #84 as it sometimes misslead to a wrong island even if the user specified the exact name. These changes will first check if there is an exact-named warp, if not, then it will check for an alternative #startingWith the given string. Previous version would check both and if either returned true, it would take the first in the arrayList.

This bug could only be reproduced if the "longer" version of name was written/created in the database/cache first because the warpLists arrayList will #findFirst() the incorrect one on index 0, while the correct one is on index 1.

Example:

Usernames: test123 and test1234

test1234 must create a warp before test123 does when wanting to warp to test123, otherwise the outcome will be as intended.