### PR TITLE
Fix null player on removeWarp

### DIFF
--- a/src/main/java/world/bentobox/warps/WarpSignsManager.java
+++ b/src/main/java/world/bentobox/warps/WarpSignsManager.java
@@ -25,6 +25,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.eclipse.jdt.annotation.NonNull;
@@ -241,11 +242,9 @@ public class WarpSignsManager {
             Entry<UUID, Location> en = it.next();
             if (en.getValue().equals(loc)) {
                 // Inform player
-                User user = User.getInstance(addon.getServer().getPlayer(en.getKey()));
-                if (user != null) {
-                    // Inform the player
-                    user.sendMessage("warps.sign-removed");
-                }
+                Optional.ofNullable(addon.getServer().getPlayer(en.getKey()))
+                        .map(User::getInstance)
+                        .ifPresent(user -> user.sendMessage("warps.sign-removed"));
                 // Remove sign from warp panel cache
                 addon.getWarpPanelManager().removeWarp(loc.getWorld(), en.getKey());
                 it.remove();


### PR DESCRIPTION
```
[10:21:18] [Server thread/WARN]: [BentoBox] Task #368746 for BentoBox v1.19.1-SNAPSHOT-LOCAL generated an exception
java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Player.getUniqueId()" because "player" is null
	at world.bentobox.bentobox.api.user.User.getInstance(User.java:82) ~[BentoBox.jar:?]
	at world.bentobox.warps.WarpSignsManager.removeWarp(WarpSignsManager.java:244) ~[Warps.jar:?]
	at world.bentobox.warps.WarpSignsManager.warpPlayer(WarpSignsManager.java:438) ~[Warps.jar:?]
	at world.bentobox.warps.commands.WarpCommand.lambda$execute$3(WarpCommand.java:71) ~[Warps.jar:?]
	at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftTask.run(CraftTask.java:101) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1569) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:495) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1485) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1284) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at net.minecraft.server.MinecraftServer.lambda$spin$1(MinecraftServer.java:321) ~[patched_1.17.1.jar:git-Pufferfish-19]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```