### PR TITLE
Closes #110, #96 - Fix level restriction

### DIFF
--- a/src/main/java/world/bentobox/warps/Warp.java
+++ b/src/main/java/world/bentobox/warps/Warp.java
@@ -224,8 +224,11 @@ public class Warp extends Addon {
         String name = this.getPlugin().getIWM().getAddon(world).map(g -> g.getDescription().getName()).orElse("");
         return this.getPlugin().getAddonsManager().getAddonByName(LEVEL_ADDON_NAME)
                 .map(l -> {
-                    if (!name.isEmpty() && ((Level) l).getSettings().getGameModes().contains(name)) {
-                        return ((Level) l).getIslandLevel(world, uniqueId);
+                    final Level addon = (Level) l;
+                    //getGameModes is a list of gamemodes that Level is DISABLED in,
+                    //so we need the opposite of the contains.
+                    if (!name.isEmpty() && !addon.getSettings().getGameModes().contains(name)) {
+                        return addon.getIslandLevel(world, uniqueId);
                     }
                     return null;
                 }).orElse(null);


### PR DESCRIPTION
Closes #110 - Closes #96 
The current logic was checking if the gamemode is DISABLED in level, which led to it not detecting correct cases. 
Tested with Level:
```
disabled-game-modes: []
```
with level under 10, was stopped correctly,
Tested with Level:
```
disabled-game-modes: 
  - BSkyBlock
```
with level under 10, was led through correctly.