### PR TITLE
Add gamemode placeholder to message

### DIFF
--- a/src/main/java/world/bentobox/warps/managers/WarpSignsManager.java
+++ b/src/main/java/world/bentobox/warps/managers/WarpSignsManager.java
@@ -363,7 +363,12 @@ public class WarpSignsManager {
             user.getWorld().playSound(Objects.requireNonNull(user.getLocation()), Sound.ENTITY_BAT_TAKEOFF, 1F, 1F);
         }
         if (!warpOwner.equals(user)) {
-            warpOwner.sendMessage("warps.player-warped", "[name]", user.getName());
+            final String gameMode = BentoBox
+                    .getInstance()
+                    .getIWM()
+                    .getFriendlyName(actualWarp.getWorld());
+
+            warpOwner.sendMessage("warps.player-warped", "[name]", user.getName(), "[gamemode]", gameMode);
         }
     }
 

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -20,7 +20,7 @@ warps:
     your-level-is: "&c Your island level is only [level] and must be higher than [required]. Run the level command."
   help: 
     description: "open the warps panel"
-  player-warped: "&2 [name] warped to your warp sign!"
+  player-warped: "&2 [name] warped to your [gamemode] warp sign!"
   sign-removed: "&c Warp sign removed!"
   success: "&a Success!"
   warpTip: "&6 Place a warp sign with [text] on the top"


### PR DESCRIPTION
Closes #89 
Add gamemode placeholder to `warps.player-warped` message.
Because the location has already been checked if it is an island world, getFriendlyName will always return the friendly name.