### PR TITLE
feat: toggle warp command

### DIFF
--- a/src/main/java/world/bentobox/warps/Warp.java
+++ b/src/main/java/world/bentobox/warps/Warp.java
@@ -288,7 +288,7 @@ public class Warp extends Addon {
         }
         return switch (requestLabel) {
             case "getSortedWarps" -> getWarpSignsManager().getSortedWarps(world);
-            case "getWarp" -> uuid == null ? null : getWarpSignsManager().getWarp(world, uuid);
+            case "getWarp" -> uuid == null ? null : getWarpSignsManager().getWarpLocation(world, uuid);
             case "getWarpMap" -> getWarpSignsManager().getWarpMap(world);
             case "hasWarp" -> uuid == null ? null : getWarpSignsManager().hasWarp(world, uuid);
             case "listWarps" -> getWarpSignsManager().listWarps(world);

--- a/src/main/java/world/bentobox/warps/Warp.java
+++ b/src/main/java/world/bentobox/warps/Warp.java
@@ -17,6 +17,7 @@ import world.bentobox.bentobox.api.flags.clicklisteners.CycleClick;
 import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.bentobox.util.Util;
 import world.bentobox.level.Level;
+import world.bentobox.warps.commands.ToggleWarpCommand;
 import world.bentobox.warps.commands.WarpCommand;
 import world.bentobox.warps.commands.WarpsCommand;
 import world.bentobox.warps.config.Settings;
@@ -100,6 +101,7 @@ public class Warp extends Addon {
             // Load the master warp and warps command
             new WarpCommand(this);
             new WarpsCommand(this);
+            new ToggleWarpCommand(this);
         }
     }
 
@@ -140,6 +142,7 @@ public class Warp extends Addon {
 
                 new WarpCommand(this, gameModeAddon.getPlayerCommand().get());
                 new WarpsCommand(this, gameModeAddon.getPlayerCommand().get());
+                new ToggleWarpCommand(this, gameModeAddon.getPlayerCommand().get());
                 this.hooked = true;
             }
         });

--- a/src/main/java/world/bentobox/warps/commands/ToggleWarpCommand.java
+++ b/src/main/java/world/bentobox/warps/commands/ToggleWarpCommand.java
@@ -1,0 +1,58 @@
+package world.bentobox.warps.commands;
+
+import org.bukkit.World;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.warps.Warp;
+import world.bentobox.warps.objects.PlayerWarp;
+
+import java.util.List;
+import java.util.UUID;
+
+public class ToggleWarpCommand extends CompositeCommand {
+
+    private final Warp addon;
+
+    public ToggleWarpCommand(Warp addon, CompositeCommand bsbIslandCmd) {
+        super(bsbIslandCmd, addon.getSettings().getToggleWarpCommand());
+        this.addon = addon;
+    }
+
+    public ToggleWarpCommand(Warp addon) {
+        super(addon.getSettings().getToggleWarpCommand());
+        this.addon = addon;
+    }
+
+
+    @Override
+    public void setup() {
+        this.setPermission(this.getParent() == null ? Warp.WELCOME_WARP_SIGNS + ".togglewarp" : "island.warp.toggle");
+        this.setOnlyPlayer(true);
+        this.setDescription("togglewarp.help.description");
+    }
+
+    @Override
+    public boolean execute(User user, String s, List<String> list) {
+        UUID userUUID = user.getUniqueId();
+        World userWorld = user.getWorld();
+
+        // Check if the user has a warp
+        boolean hasWarp = addon.getWarpSignsManager().hasWarp(userWorld, userUUID);
+
+        if (hasWarp) {
+            // If the user has a warp, toggle its visibility
+            PlayerWarp warp = addon.getWarpSignsManager().getPlayerWarp(userWorld, userUUID);
+            // Check extreme case if PlayerWarp is null
+            if (warp == null) {
+                user.sendMessage("togglewarp.error.generic");
+                return false;
+            }
+            warp.toggle();
+            String message = warp.isEnabled() ? "togglewarp.enabled" : "togglewarp.disabled";
+            user.sendMessage(message);
+        } else {
+            user.sendMessage("togglewarp.error.no-warp");
+        }
+        return false;
+    }
+}

--- a/src/main/java/world/bentobox/warps/commands/ToggleWarpCommand.java
+++ b/src/main/java/world/bentobox/warps/commands/ToggleWarpCommand.java
@@ -1,9 +1,11 @@
 package world.bentobox.warps.commands;
 
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.warps.Warp;
+import world.bentobox.warps.event.WarpToggleEvent;
 import world.bentobox.warps.objects.PlayerWarp;
 
 import java.util.List;
@@ -48,6 +50,7 @@ public class ToggleWarpCommand extends CompositeCommand {
                 return false;
             }
             warp.toggle();
+            Bukkit.getPluginManager().callEvent(new WarpToggleEvent(userUUID, warp));
             String message = warp.isEnabled() ? "togglewarp.enabled" : "togglewarp.disabled";
             user.sendMessage(message);
         } else {

--- a/src/main/java/world/bentobox/warps/commands/WarpCommand.java
+++ b/src/main/java/world/bentobox/warps/commands/WarpCommand.java
@@ -50,12 +50,12 @@ public class WarpCommand extends DelayedTeleportCommand {
                 user.sendMessage("warps.warpTip", "[text]", addon.getSettings().getWelcomeLine());
                 return false;
             } else {
-                // Attemp to find warp with exact player's name
+                // Attempt to find warp with exact player's name
                 UUID foundWarp = warpList.stream().filter(u -> getPlayers().getName(u).equalsIgnoreCase(args.get(0))).findFirst().orElse(null);
 
                 if (foundWarp == null) {
 
-                    // Atempt to find warp which starts with the given name
+                    // Attempt to find warp which starts with the given name
                     UUID foundAlernativeWarp = warpList.stream().filter(u -> getPlayers().getName(u).toLowerCase().startsWith(args.get(0).toLowerCase())).findFirst().orElse(null);
 
                     if (foundAlernativeWarp == null) {

--- a/src/main/java/world/bentobox/warps/config/Settings.java
+++ b/src/main/java/world/bentobox/warps/config/Settings.java
@@ -212,7 +212,7 @@ public class Settings implements ConfigObject
      * @return the toggleWarpCommand
      */
     public String getToggleWarpCommand() {
-        return "togglewarp";
+        return toggleWarpCommand;
     }
 
     /**

--- a/src/main/java/world/bentobox/warps/config/Settings.java
+++ b/src/main/java/world/bentobox/warps/config/Settings.java
@@ -61,6 +61,8 @@ public class Settings implements ConfigObject
     String warpCommand = "warp";
     @ConfigEntry(path = "warps-command")
     String warpsCommand = "warps";
+    @ConfigEntry(path = "togglewarp-command")
+    String toggleWarpCommand = "togglewarp";
 
     // ---------------------------------------------------------------------
     // Section: Constructor
@@ -203,6 +205,21 @@ public class Settings implements ConfigObject
      */
     public void setWarpsCommand(String warpsCommand) {
         this.warpsCommand = warpsCommand;
+    }
+
+
+    /**
+     * @return the toggleWarpCommand
+     */
+    public String getToggleWarpCommand() {
+        return "togglewarp";
+    }
+
+    /**
+     * @param toggleWarpCommand the toggleWarpCommand to set
+     */
+    public void setToggleWarpCommand(String toggleWarpCommand) {
+        this.toggleWarpCommand = toggleWarpCommand;
     }
 
     /**

--- a/src/main/java/world/bentobox/warps/event/WarpToggleEvent.java
+++ b/src/main/java/world/bentobox/warps/event/WarpToggleEvent.java
@@ -1,0 +1,72 @@
+package world.bentobox.warps.event;
+
+import org.bukkit.Location;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import world.bentobox.warps.objects.PlayerWarp;
+
+import java.util.UUID;
+
+/**
+ * This event is fired when a warp is toggled
+ * A Listener to this event can use it only to get information. e.g: broadcast something
+ *
+ * @since 1.16.0
+ * @author TreemanKing
+ */
+public class WarpToggleEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final UUID user;
+    private final PlayerWarp playerWarp;
+
+    public WarpToggleEvent(UUID user, PlayerWarp playerWarp) {
+        this.playerWarp = playerWarp;
+        this.user = user;
+    }
+
+    /**
+     * Gets the user who has toggled the warp
+     *
+     * @return the UUID of the player who toggled the warp
+     */
+    public UUID getUser() {
+        return user;
+    }
+
+    /**
+     * Gets the state of the warp
+     *
+     * @return true if the warp is enabled, false otherwise
+     */
+    public boolean isEnabled() {
+        return playerWarp.isEnabled();
+    }
+
+    /**
+     * Gets the PlayerWarp object
+     *
+     * @return the PlayerWarp object
+     */
+    public PlayerWarp getPlayerWarp() {
+        return playerWarp;
+    }
+
+    /**
+     * Gets the location of the toggled warp
+     *
+     * @return the location of the warp
+     */
+    public Location getLocation() {
+        return playerWarp.getLocation();
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/world/bentobox/warps/listeners/WarpSignsListener.java
+++ b/src/main/java/world/bentobox/warps/listeners/WarpSignsListener.java
@@ -171,7 +171,7 @@ public class WarpSignsListener implements Listener {
             }
 
             // Check if the player already has a sign
-            final Location oldSignLoc = addon.getWarpSignsManager().getWarp(b.getWorld(), user.getUniqueId());
+            final Location oldSignLoc = addon.getWarpSignsManager().getWarpLocation(b.getWorld(), user.getUniqueId());
             if (oldSignLoc != null) {
                 // A sign already exists. Check if it still there and if
                 // so,

--- a/src/main/java/world/bentobox/warps/listeners/WarpSignsListener.java
+++ b/src/main/java/world/bentobox/warps/listeners/WarpSignsListener.java
@@ -28,6 +28,7 @@ import world.bentobox.bentobox.api.events.team.TeamLeaveEvent;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.Util;
+import world.bentobox.warps.objects.PlayerWarp;
 import world.bentobox.warps.Warp;
 import world.bentobox.warps.event.WarpRemoveEvent;
 
@@ -60,12 +61,12 @@ public class WarpSignsListener implements Listener {
             @Override
             public void run() {
                 boolean changed = false;
-                Iterator<Map.Entry<UUID, Location>> iterator =
+                Iterator<Map.Entry<UUID, PlayerWarp>> iterator =
                         addon.getWarpSignsManager().getWarpMap(event.getWorld()).entrySet().iterator();
                 while (iterator.hasNext()) {
-                    Map.Entry<UUID, Location> entry = iterator.next();
+                    Map.Entry<UUID, PlayerWarp> entry = iterator.next();
                     UUID uuid = entry.getKey();
-                    Location location = entry.getValue();
+                    Location location = entry.getValue().getLocation();
                     if (event.getChunk().getX() == location.getBlockX() >> 4
                             && event.getChunk().getZ() == location.getBlockZ() >> 4
                             && !Tag.SIGNS.isTagged(location.getBlock().getType())) {
@@ -126,16 +127,16 @@ public class WarpSignsListener implements Listener {
 
     private boolean isPlayersSign(Player player, Block b, boolean inWorld) {
         // Welcome sign detected - check to see if it is this player's sign
-        Map<UUID, Location> list = addon.getWarpSignsManager().getWarpMap(b.getWorld());
+        Map<UUID, PlayerWarp> list = addon.getWarpSignsManager().getWarpMap(b.getWorld());
         String reqPerm = inWorld ? addon.getPermPrefix(b.getWorld()) + "mod.removesign" : Warp.WELCOME_WARP_SIGNS + ".mod.removesign";
-        return ((list.containsKey(player.getUniqueId()) && list.get(player.getUniqueId()).equals(b.getLocation()))
+        return ((list.containsKey(player.getUniqueId()) && list.get(player.getUniqueId()).getLocation().equals(b.getLocation()))
                 || player.isOp()  || player.hasPermission(reqPerm));
     }
 
     private boolean isWarpSign(Block b) {
         Sign s = (Sign) b.getState();
         return s.getLine(0).equalsIgnoreCase(ChatColor.GREEN + addon.getSettings().getWelcomeLine())
-                && addon.getWarpSignsManager().getWarpMap(b.getWorld()).containsValue(s.getLocation());
+                && addon.getWarpSignsManager().getWarpMap(b.getWorld()).values().stream().anyMatch(playerWarp -> playerWarp.getLocation().equals(s.getLocation()));
     }
 
     /**
@@ -216,15 +217,15 @@ public class WarpSignsListener implements Listener {
 
         final Island island = e.getIsland();
 
-        final Map<UUID, Location> islandWarps = addon
+        final Map<UUID, PlayerWarp> islandWarps = addon
                 .getWarpSignsManager()
                 .getWarpMap(island.getWorld())
                 .entrySet()
                 .stream()
-                .filter(x -> island.inIslandSpace(x.getValue()))
+                .filter(x -> island.inIslandSpace(x.getValue().getLocation()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-        for(Map.Entry<UUID, Location> entry : islandWarps.entrySet()) {
+        for(Map.Entry<UUID, PlayerWarp> entry : islandWarps.entrySet()) {
             if(island.getRank(entry.getKey()) >= e.getSetTo()) continue;
 
             //The user has a lower rank than the new set value.

--- a/src/main/java/world/bentobox/warps/managers/WarpSignsManager.java
+++ b/src/main/java/world/bentobox/warps/managers/WarpSignsManager.java
@@ -169,6 +169,10 @@ public class WarpSignsManager {
         // Bigger value of time means a more recent login
         TreeMap<Long, UUID> map = new TreeMap<>();
         getWarpMap(world).forEach((uuid, value) -> {
+            // If the warp is not enabled, skip this iteration
+            if (!value.isEnabled()) {
+                return;
+            }
             // If never played, will be zero
             long lastPlayed = addon.getServer().getOfflinePlayer(uuid).getLastPlayed();
             // This aims to avoid the chance that players logged off at exactly the same time
@@ -197,7 +201,11 @@ public class WarpSignsManager {
     public Set<UUID> listWarps(@NonNull World world) {
         // Remove any null locations
         getWarpMap(world).values().removeIf(Objects::isNull);
-        return getWarpMap(world).entrySet().stream().filter(e -> Util.sameWorld(world, Objects.requireNonNull(e.getValue().getLocation().getWorld()))).map(Map.Entry::getKey).collect(Collectors.toSet());
+        // Remove any warps that have not been toggled on
+        Map<UUID, PlayerWarp> enabledWarps = getWarpMap(world).entrySet().stream()
+                .filter(entry -> entry.getValue().isEnabled())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return enabledWarps.keySet();
     }
 
     /**

--- a/src/main/java/world/bentobox/warps/managers/WarpSignsManager.java
+++ b/src/main/java/world/bentobox/warps/managers/WarpSignsManager.java
@@ -122,9 +122,14 @@ public class WarpSignsManager {
      * @return Location of warp or null
      */
     @Nullable
-    public Location getWarp(World world, UUID playerUUID) {
+    public Location getWarpLocation(World world, UUID playerUUID) {
         PlayerWarp playerWarp = getWarpMap(world).get(playerUUID);
         return playerWarp != null ? playerWarp.getLocation() : null;
+    }
+
+    @Nullable
+    public PlayerWarp getPlayerWarp(World world, UUID playerUUID) {
+        return getWarpMap(world).get(playerUUID);
     }
 
     /**
@@ -304,7 +309,7 @@ public class WarpSignsManager {
     @NonNull
     public SignCacheItem getSignInfo(@NonNull World world, @NonNull UUID uuid) {
         //get the sign info
-        Location signLocation = getWarp(world, uuid);
+        Location signLocation = getWarpLocation(world, uuid);
         if (signLocation == null || !signLocation.getBlock().getType().name().contains("SIGN")) {
             return new SignCacheItem();
         }
@@ -398,7 +403,7 @@ public class WarpSignsManager {
      * @param owner - owner of the warp
      */
     public void warpPlayer(@NonNull World world, @NonNull User user, @NonNull UUID owner) {
-        final Location warpSpot = getWarp(world, owner);
+        final Location warpSpot = getWarpLocation(world, owner);
         // Check if the warp spot is safe
         if (warpSpot == null) {
             user.sendMessage("warps.error.does-not-exist");

--- a/src/main/java/world/bentobox/warps/objects/PlayerWarp.java
+++ b/src/main/java/world/bentobox/warps/objects/PlayerWarp.java
@@ -1,0 +1,32 @@
+package world.bentobox.warps.objects;
+
+import com.google.gson.annotations.Expose;
+import org.bukkit.Location;
+
+import java.io.Serializable;
+
+public class PlayerWarp implements Serializable {
+
+    @Expose
+    private final Location location;
+
+    @Expose
+    private boolean isEnabled;
+
+    public PlayerWarp(Location location, boolean isEnabled) {
+        this.location = location;
+        this.isEnabled = isEnabled;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public void toggle() {
+        isEnabled = !isEnabled;
+    }
+}

--- a/src/main/java/world/bentobox/warps/objects/WarpsData.java
+++ b/src/main/java/world/bentobox/warps/objects/WarpsData.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import org.bukkit.Location;
 import org.bukkit.World;
 
 import com.google.gson.annotations.Expose;
@@ -18,7 +17,7 @@ public class WarpsData implements DataObject {
     @Expose
     private String uniqueId = "warps";
     @Expose
-    private Map<Location, UUID> warpSigns = new HashMap<>();
+    private Map<PlayerWarp, UUID> warpSigns = new HashMap<>();
 
     public WarpsData() {
         // Required by YAML database
@@ -34,24 +33,24 @@ public class WarpsData implements DataObject {
         this.uniqueId = uniqueId;
     }
 
-    public Map<Location,  UUID> getWarpSigns() {
+    public Map<PlayerWarp,  UUID> getWarpSigns() {
         if (warpSigns == null)
             return new HashMap<>();
         return warpSigns;
     }
 
-    public void setWarpSigns(Map<Location, UUID> warpSigns) {
+    public void setWarpSigns(Map<PlayerWarp, UUID> warpSigns) {
         this.warpSigns = warpSigns;
     }
 
     /**
-     * Puts all the data from the map into this objects ready for saving
+     * Puts all the data from the map into these objects ready for saving
      * @param worldsWarpList 2D map of warp locations by world vs UUID
      * @return this class filled with data
      */
-    public WarpsData save(Map<World, Map<UUID, Location>> worldsWarpList) {
+    public WarpsData save(Map<World, Map<UUID, PlayerWarp>> worldsWarpList) {
         getWarpSigns().clear();
-        worldsWarpList.values().forEach(world -> world.forEach((uuid,location) -> warpSigns.put(location, uuid)));
+        worldsWarpList.values().forEach(world -> world.forEach((uuid,playerWarp) -> warpSigns.put(playerWarp, uuid)));
         return this;
     }
 

--- a/src/main/java/world/bentobox/warps/objects/WarpsData.java
+++ b/src/main/java/world/bentobox/warps/objects/WarpsData.java
@@ -57,6 +57,7 @@ public class WarpsData implements DataObject {
             PlayerWarp playerWarp = new PlayerWarp(entry.getKey(), true);
             newWarpSigns.put(playerWarp, entry.getValue());
         }
+        warpSigns.clear();
     }
 
     public void setWarpSigns(Map<PlayerWarp, UUID> warpSigns) {

--- a/src/main/java/world/bentobox/warps/objects/WarpsData.java
+++ b/src/main/java/world/bentobox/warps/objects/WarpsData.java
@@ -57,7 +57,7 @@ public class WarpsData implements DataObject {
             PlayerWarp playerWarp = new PlayerWarp(entry.getKey(), true);
             newWarpSigns.put(playerWarp, entry.getValue());
         }
-        warpSigns.clear();
+        warpSigns = null;
     }
 
     public void setWarpSigns(Map<PlayerWarp, UUID> warpSigns) {

--- a/src/main/java/world/bentobox/warps/objects/WarpsData.java
+++ b/src/main/java/world/bentobox/warps/objects/WarpsData.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import org.bukkit.Location;
 import org.bukkit.World;
 
 import com.google.gson.annotations.Expose;
@@ -16,8 +17,12 @@ public class WarpsData implements DataObject {
 
     @Expose
     private String uniqueId = "warps";
+
+    @Deprecated @Expose
+    private Map<Location, UUID> warpSigns = new HashMap<>();
+
     @Expose
-    private Map<PlayerWarp, UUID> warpSigns = new HashMap<>();
+    private Map<PlayerWarp, UUID> newWarpSigns = new HashMap<>();
 
     public WarpsData() {
         // Required by YAML database
@@ -34,13 +39,28 @@ public class WarpsData implements DataObject {
     }
 
     public Map<PlayerWarp,  UUID> getWarpSigns() {
-        if (warpSigns == null)
+        convertOldWarpSigns();
+        if (newWarpSigns == null)
             return new HashMap<>();
-        return warpSigns;
+        return newWarpSigns;
+    }
+
+    /**
+     * Method for converting old warp signs to new warp signs
+     */
+    public void convertOldWarpSigns() {
+        if (warpSigns == null) {
+            return;
+        }
+
+        for (Map.Entry<Location, UUID> entry : warpSigns.entrySet()) {
+            PlayerWarp playerWarp = new PlayerWarp(entry.getKey(), true);
+            newWarpSigns.put(playerWarp, entry.getValue());
+        }
     }
 
     public void setWarpSigns(Map<PlayerWarp, UUID> warpSigns) {
-        this.warpSigns = warpSigns;
+        this.newWarpSigns = warpSigns;
     }
 
     /**
@@ -50,7 +70,7 @@ public class WarpsData implements DataObject {
      */
     public WarpsData save(Map<World, Map<UUID, PlayerWarp>> worldsWarpList) {
         getWarpSigns().clear();
-        worldsWarpList.values().forEach(world -> world.forEach((uuid,playerWarp) -> warpSigns.put(playerWarp, uuid)));
+        worldsWarpList.values().forEach(world -> world.forEach((uuid,playerWarp) -> newWarpSigns.put(playerWarp, uuid)));
         return this;
     }
 

--- a/src/main/java/world/bentobox/warps/panels/Utils.java
+++ b/src/main/java/world/bentobox/warps/panels/Utils.java
@@ -52,7 +52,7 @@ public class Utils
             List<String> permissions = user.getEffectivePermissions().stream().
                 map(PermissionAttachmentInfo::getPermission).
                 filter(permission -> permission.startsWith(permPrefix)).
-                collect(Collectors.toList());
+                    toList();
 
             for (String permission : permissions)
             {

--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -18,3 +18,6 @@ permissions:
   '[gamemode].island.addwarp':
     description: Player can create a welcome warp sign
     default: true
+  '[gamemode].island.togglewarp':
+    description: Player can toggle a warp sign
+    default: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,3 +33,4 @@ allow-in-other-worlds: false
 # Warp and warps commands. You can change them if they clash with other addons or plugins.
 warp-command: warp
 warps-command: warps
+togglewarp-command: togglewarp

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -60,6 +60,16 @@ warps:
     # Prefix for messages that are send from server.
     prefix: "&l&6 [BentoBox]: &r"
 
+togglewarp:
+  help:
+    description: "toggle the warp sign"
+  enabled: "&a Your warp is now visible!"
+  disabled: "&c Your warp is now hidden!"
+  error:
+    no-permission: "&c You do not have permission to do that!"
+    generic: "&c An error occurred while toggling your warp."
+    no-warp: "&c You do not have a warp to toggle!"
+
 protection:
   flags:
     PLACE_WARP:

--- a/src/test/java/world/bentobox/warps/WarpSignsManagerTest.java
+++ b/src/test/java/world/bentobox/warps/WarpSignsManagerTest.java
@@ -67,6 +67,7 @@ import world.bentobox.warps.event.WarpCreateEvent;
 import world.bentobox.warps.event.WarpInitiateEvent;
 import world.bentobox.warps.managers.SignCacheManager;
 import world.bentobox.warps.managers.WarpSignsManager;
+import world.bentobox.warps.objects.PlayerWarp;
 import world.bentobox.warps.objects.WarpsData;
 
 
@@ -195,7 +196,7 @@ public class WarpSignsManagerTest {
 
         // Handler
         when(handler.objectExists("warps")).thenReturn(true);
-        Map<Location, UUID> warpMap = Collections.singletonMap(location, uuid);
+        Map<PlayerWarp, UUID> warpMap = Collections.singletonMap(new PlayerWarp(location, true), uuid);
         when(load.getWarpSigns()).thenReturn(warpMap);
         when(handler.loadObject(anyString())).thenReturn(load);
 
@@ -275,7 +276,8 @@ public class WarpSignsManagerTest {
      */
     @Test
     public void testGetWarpMapNullLocation() {
-        Map<Location, UUID> warpMap = Collections.singletonMap(null, uuid);
+        PlayerWarp playerWarp = new PlayerWarp(null, true);
+        Map<PlayerWarp, UUID> warpMap = Collections.singletonMap(playerWarp, uuid);
         when(load.getWarpSigns()).thenReturn(warpMap);
         wsm = new WarpSignsManager(addon, plugin);
         assertTrue("Map is not empty", wsm.getWarpMap(world).isEmpty());

--- a/src/test/java/world/bentobox/warps/WarpSignsManagerTest.java
+++ b/src/test/java/world/bentobox/warps/WarpSignsManagerTest.java
@@ -359,19 +359,19 @@ public class WarpSignsManagerTest {
     }
 
     /**
-     * Test method for {@link WarpSignsManager#getWarp(org.bukkit.World, java.util.UUID)}.
+     * Test method for {@link WarpSignsManager#getWarpLocation(org.bukkit.World, java.util.UUID)}.
      */
     @Test
     public void testGetWarpWorldWorld() {
-        assertNull(wsm.getWarp(mock(World.class), uuid));
+        assertNull(wsm.getWarpLocation(mock(World.class), uuid));
     }
 
     /**
-     * Test method for {@link WarpSignsManager#getWarp(org.bukkit.World, java.util.UUID)}.
+     * Test method for {@link WarpSignsManager#getWarpLocation(org.bukkit.World, java.util.UUID)}.
      */
     @Test
     public void testGetWarp() {
-        assertEquals(location, wsm.getWarp(world, uuid));
+        assertEquals(location, wsm.getWarpLocation(world, uuid));
     }
 
     /**

--- a/src/test/java/world/bentobox/warps/listeners/WarpSignsListenerTest.java
+++ b/src/test/java/world/bentobox/warps/listeners/WarpSignsListenerTest.java
@@ -50,6 +50,7 @@ import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.bentobox.managers.LocalesManager;
 import world.bentobox.bentobox.managers.PlaceholdersManager;
 import world.bentobox.bentobox.util.Util;
+import world.bentobox.warps.objects.PlayerWarp;
 import world.bentobox.warps.Warp;
 import world.bentobox.warps.managers.WarpSignsManager;
 import world.bentobox.warps.config.Settings;
@@ -123,12 +124,12 @@ public class WarpSignsListenerTest {
         when(block.getState()).thenReturn(s);
         // warp signs manager
         when(addon.getWarpSignsManager()).thenReturn(wsm);
-        Map<UUID, Location> list = new HashMap<>();
+        Map<UUID, PlayerWarp> list = new HashMap<>();
         Location location = mock(Location.class);
         when(location.getBlock()).thenReturn(block);
         when(s.getLocation()).thenReturn(location);
         when(block.getLocation()).thenReturn(location);
-        list.put(uuid, location);
+        list.put(uuid, new PlayerWarp(location, true));
         // Player is in world
         when(wsm.getWarpMap(world)).thenReturn(list);
         //Player has a warp sign already here
@@ -339,8 +340,8 @@ public class WarpSignsListenerTest {
         when(settings.getRemoveExistingWarpsWhenFlagChanges()).thenReturn(true);
         WarpSignsListener wsl = new WarpSignsListener(addon);
 
-        Map<UUID, Location> warps = Map.of(
-                player.getUniqueId(), block.getLocation()
+        Map<UUID, PlayerWarp> warps = Map.of(
+                player.getUniqueId(), new PlayerWarp(block.getLocation(), true)
         );
 
         when(wsm.getWarpMap(any())).thenReturn(warps);

--- a/src/test/java/world/bentobox/warps/listeners/WarpSignsListenerTest.java
+++ b/src/test/java/world/bentobox/warps/listeners/WarpSignsListenerTest.java
@@ -133,7 +133,7 @@ public class WarpSignsListenerTest {
         // Player is in world
         when(wsm.getWarpMap(world)).thenReturn(list);
         //Player has a warp sign already here
-        when(wsm.getWarp(any(), any())).thenReturn(location);
+        when(wsm.getWarpLocation(any(), any())).thenReturn(location);
         // Unique spot
         when(wsm.addWarp(any(), any())).thenReturn(true);
         // Bentobox
@@ -421,7 +421,7 @@ public class WarpSignsListenerTest {
 
     @Test
     public void testCreateNoSignAlreadyUniqueSpot() {
-        when(wsm.getWarp(any(), any())).thenReturn(null);
+        when(wsm.getWarpLocation(any(), any())).thenReturn(null);
         when(player.hasPermission(anyString())).thenReturn(true);
         WarpSignsListener wsl = new WarpSignsListener(addon);
         SignChangeEvent e = new SignChangeEvent(block, player, lines);


### PR DESCRIPTION
closes #6 

Probably needs some checking around the code. I couldn't figure out a great way on how to deal with the storage of `warpData` and changing it completely to `newWarpData` as you'll see in the code. 

The tests for the new commands and such are required to be done but I've tested the following in a live server to make sure it works:
- Conversion to `Map<UUID, PlayerWarp>` from a `Map<UUID, Location>` stored in database (for some reason, it doesn't convert to `newWarpData` until some edits or makes a new warp which is confusing)
- Toggling of Warp

If there is any suggestions, please let me know.