### PR TITLE
fix (partial): other worlds can be used

### DIFF
--- a/src/main/java/world/bentobox/warps/listeners/WarpSignsListener.java
+++ b/src/main/java/world/bentobox/warps/listeners/WarpSignsListener.java
@@ -158,6 +158,11 @@ public class WarpSignsListener implements Listener {
             if (noPerms(user, b.getWorld(), inWorld)) {
                 return;
             }
+            // TODO: These checks are useless if the sign is placed outside a BSB world.
+            //  This will mean level and rank requirements are nil in the case of allow-in-other-worlds: true.
+            //  I'm not sure if there is a better way around this without adding new API checking for primary
+            //  or last island accessed with relevant permissions.
+            // ignored.
             if (inWorld && noLevelOrIsland(user, b.getWorld())) {
                 e.setLine(0, ChatColor.RED + addon.getSettings().getWelcomeLine());
                 return;

--- a/src/main/java/world/bentobox/warps/listeners/WarpSignsListener.java
+++ b/src/main/java/world/bentobox/warps/listeners/WarpSignsListener.java
@@ -163,7 +163,7 @@ public class WarpSignsListener implements Listener {
                 return;
             }
 
-            if(!hasCorrectIslandRank(b, user)) {
+            if (inWorld && !hasCorrectIslandRank(b, user)) {
                 e.setLine(0, ChatColor.RED + addon.getSettings().getWelcomeLine());
                 user.sendMessage("warps.error.not-correct-rank");
                 return;


### PR DESCRIPTION
After the creation of #117, the use of the setting `allow-in-other-worlds: true` has became redundant as it goes into `hasCorrectIslandRank`. This will always be false as there is no island at the sign where the block is placed in another world that isn't an Island. 

This fixes this by adding a `inWorld` check, however it should be noted that this isn't a true fix. 
If we wanted to implement a true fix, we would require the island where the user was last owner/had flag permissions to create a warp is used, without using "world" in the method. Getting the last primary island might be the way to go but new API would be required in order to access this as there is no way to get the world in this case in non-BSB worlds. I have added a TODO as well to make sure this isn't lost whilst reading/understanding the code whilst posing a possible solution if new API comes to light.
